### PR TITLE
Remove unnecessary runtime 'if' in extend-freeze macro.

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -1097,7 +1097,7 @@
 (defn- read-record [in class-name]
   (let [content (thaw-from-in! in)]
     (try
-      (let [class  (Class/forName class-name)
+      (let [class  (clojure.lang.RT/classForName class-name)
             method (.getMethod class "create" class-method-sig)]
         (.invoke method class (into-array Object [content])))
       (catch Exception e

--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -1426,14 +1426,14 @@
     (.writeUTF [data-output] (:data x)))"
   [type custom-type-id [x out] & body]
   (assert-custom-type-id custom-type-id)
-  `(extend-type ~type IFreezable1
-     (~'-freeze-without-meta! [~x ~(with-meta out {:tag 'java.io.DataOutput})]
-       (if-not ~(keyword? custom-type-id)
+  `(extend-type ~type nippy/IFreezable1
+     (-freeze-without-meta! [~x ~(with-meta out {:tag 'java.io.DataOutput})]
+       ~(if-not (keyword? custom-type-id)
          ;; Unprefixed [cust byte id][payload]:
-         (write-id ~out ~(coerce-custom-type-id custom-type-id))
+         `(write-id ~out ~(coerce-custom-type-id custom-type-id))
          ;; Prefixed [const byte id][cust hash id][payload]:
-         (do (write-id    ~out ~id-prefixed-custom)
-             (.writeShort ~out ~(coerce-custom-type-id custom-type-id))))
+         `(do (nippy/write-id    ~out ~id-prefixed-custom)
+              (.writeShort ~out ~(coerce-custom-type-id custom-type-id))))
       ~@body)))
 
 (defmacro extend-thaw

--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -1426,13 +1426,13 @@
     (.writeUTF [data-output] (:data x)))"
   [type custom-type-id [x out] & body]
   (assert-custom-type-id custom-type-id)
-  `(extend-type ~type nippy/IFreezable1
+  `(extend-type ~type IFreezable1
      (-freeze-without-meta! [~x ~(with-meta out {:tag 'java.io.DataOutput})]
        ~(if-not (keyword? custom-type-id)
          ;; Unprefixed [cust byte id][payload]:
          `(write-id ~out ~(coerce-custom-type-id custom-type-id))
          ;; Prefixed [const byte id][cust hash id][payload]:
-         `(do (nippy/write-id    ~out ~id-prefixed-custom)
+         `(do (write-id    ~out ~id-prefixed-custom)
               (.writeShort ~out ~(coerce-custom-type-id custom-type-id))))
       ~@body)))
 

--- a/test/taoensso/nippy/tests/main.clj
+++ b/test/taoensso/nippy/tests/main.clj
@@ -232,6 +232,15 @@
             (range 50))]
       (every? deref futures))))
 
+;;;; Redefs
+
+(defrecord MyFoo [] Object (toString [_] "v1"))
+(str (thaw (freeze (MyFoo.))))
+(defrecord MyFoo [] Object (toString [_] "v2"))
+
+(deftest _redefs
+  (is (= (str (thaw (freeze (MyFoo.)))) "v2")))
+
 ;;;; Benchmarks
 
 (deftest _benchmarks


### PR DESCRIPTION
Hello. A small optimisation: I just noticed the extend-freeze macro has an if checking whether the type ID is a keyword or not. Since this is constant at run time, I've changed the macro to emit the result of the if, rather than check the type ID on every call.