### PR TITLE
Fixes #128 - robust serialization for java.time.Instant

### DIFF
--- a/src/taoensso/nippy/java_time.clj
+++ b/src/taoensso/nippy/java_time.clj
@@ -1,0 +1,23 @@
+(ns taoensso.nippy.java-time
+  (:require [taoensso.nippy :as nippy])
+  (:import [java.time Instant]))
+
+
+(nippy/extend-freeze
+ Instant :java.time/instant
+ [^Instant instant out]
+ (nippy/-freeze-without-meta! [(.getEpochSecond instant)
+                               (long (.getNano instant))] out))
+
+
+(nippy/extend-thaw
+ :java.time/instant
+ [in]
+ (let [[seconds nanos] (nippy/thaw-from-in! in)]
+   (Instant/ofEpochSecond seconds nanos)))
+
+
+(comment
+  (let [inst (Instant/now)]
+    (= inst (nippy/thaw (nippy/freeze inst))))
+  )

--- a/test/taoensso/nippy/tests/main.clj
+++ b/test/taoensso/nippy/tests/main.clj
@@ -6,6 +6,8 @@
    [clojure.test.check.properties :as tc-props]
    [taoensso.encore :as enc   :refer ()]
    [taoensso.nippy  :as nippy :refer (freeze thaw)]
+   ;;java-time support for nippy
+   [taoensso.nippy.java-time]
    [taoensso.nippy.benchmarks :as benchmarks]))
 
 (comment (test/run-tests))
@@ -332,6 +334,11 @@
           )))
 
     "Metadata successfully excluded by freeze"))
+
+
+(deftest java-time-extension-test
+  (let [inst (java.time.Instant/now)]
+    (is (= inst (nippy/thaw (nippy/freeze inst))))))
 
 ;;;; Benchmarks
 


### PR DESCRIPTION
We propose adding java-time as a simple extension namespace that first makes a version independent data structure out of the java.time object and then serializes to and from that ds to avoid java serialization version issues/conflicts.