### PR TITLE
Ensure length of medium sized keyword is written as a Short.

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -649,7 +649,7 @@
 
       (md-count? len)
       (do (write-id       out id-kw-md)
-          (write-lg-count out len))
+          (write-md-count out len))
 
       ;; :else ; Unrealistic
       ;; (do (write-id       out id-kw-lg)


### PR DESCRIPTION
Hello there! We were recently trying to bump nippy versions within Crux, though we ran into some issues within our tests. I wrote up my findings in more detail here https://github.com/juxt/crux/pull/1249#issuecomment-729085399, but essentially it was caused by this line within `write-kw` where the length of a medium sized keyword was being written as an **Integer** rather than a **Short**.