### PR TITLE
Fix issue with `Boolean` freezing

### DIFF
--- a/src/taoensso/nippy.clj
+++ b/src/taoensso/nippy.clj
@@ -1151,7 +1151,7 @@
   (.writeLong out (.getMostSignificantBits  x))
   (.writeLong out (.getLeastSignificantBits x)))
 
-(freezer Boolean              (if x (write-id out id-true) (write-id out id-false)))
+(freezer Boolean              (if (boolean x) (write-id out id-true) (write-id out id-false)))
 (freezer (Class/forName "[B")                  (write-bytes   out x))
 (freezer (Class/forName "[Ljava.lang.Object;") (write-objects out x))
 (freezer String               (write-str   out x))


### PR DESCRIPTION
Hello, I think I caught an issue with java's Boolean objects handling.

```
(-> (Boolean. false) nippy/freeze nippy/thaw)
;; => true
```

It fixes #89 too